### PR TITLE
Firefox 105.0.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Manual variables
-VERSION = "105.0.2"
-SHASUM  = "df0f62a80635e7d50386cfab9a8c441d0a5e33268c7d3c3be547bf91ba5d802d"
+VERSION = "105.0.3"
+SHASUM  = "e334d4dfbe4be20e6acf42a5c1915cd326b5a1112e6465537cab6efe7ebae50f"
 
 # Automatic variables
 ARCH    = "$(shell uname -m)"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+firefox (105.0.3) jammy; urgency=medium
+
+  * https://www.mozilla.org/en-US/firefox/105.0.3/releasenotes/
+
+ -- Jacob Kauffmann <jacob@system76.com>  Fri, 07 Oct 2022 16:16:00 -0600
+
 firefox (105.0.2) jammy; urgency=medium
 
   * https://www.mozilla.org/en-US/firefox/105.0.2/releasenotes/


### PR DESCRIPTION
https://www.mozilla.org/en-US/firefox/105.0.3/releasenotes/

Not sure if we actually need this, as the release notes indicate the only change was made for Windows.