### PR TITLE
Firefox 106.0.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Manual variables
-VERSION = "106.0.2"
-SHASUM  = "4867a211001cc289fbe8ee5eaa04f72691d9a61e44f7c5ddb339ba8a37501bac"
+VERSION = "106.0.3"
+SHASUM  = "0c18141ededd6c969f00275eaf26d05933f71bf14143d70d4f5fa74df9411155"
 
 # Automatic variables
 ARCH    = "$(shell uname -m)"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+firefox (106.0.3) jammy; urgency=medium
+
+  * https://www.mozilla.org/firefox/106.0.3/releasenotes/
+
+ -- Jacob Kauffmann <jacob@system76.com>  Mon, 31 Oct 2022 09:34:37 -0600
+
 firefox (106.0.2) jammy; urgency=medium
 
   * https://www.mozilla.org/firefox/106.0.2/releasenotes/


### PR DESCRIPTION
https://www.mozilla.org/firefox/106.0.3/releasenotes/

This is another version where the release notes only list changes for Windows, so it may not be necessary on Pop!_OS (and can probably take a lower priority than other PRs if needed.)