### PR TITLE
Firefox 107.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Manual variables
-VERSION = "106.0.3"
-SHASUM  = "0c18141ededd6c969f00275eaf26d05933f71bf14143d70d4f5fa74df9411155"
+VERSION = "107.0"
+SHASUM  = "6eff8b2938267bb0dc4018012764c19d25d36c2d2709582ae225a2db228c0472"
 
 # Automatic variables
 ARCH    = "$(shell uname -m)"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+firefox (107.0) jammy; urgency=medium
+
+  * https://www.mozilla.org/en-US/firefox/107.0/releasenotes/
+
+ -- Jacob Kauffmann <jacob@system76.com>  Wed, 16 Nov 2022 13:49:52 -0700
+
 firefox (106.0.3) jammy; urgency=medium
 
   * https://www.mozilla.org/firefox/106.0.3/releasenotes/


### PR DESCRIPTION
https://www.mozilla.org/en-US/firefox/107.0/releasenotes/ 

Not sure why this version didn't get a notification sent out on the mailing list yesterday.